### PR TITLE
clang14 on debian12 complains about a type mismatch error without this

### DIFF
--- a/Applications/Network/AppController.h
+++ b/Applications/Network/AppController.h
@@ -42,7 +42,7 @@
   NMSetup       *nmSetupPanel;
   NetworkInfo   *networkInfo;
 
-  DKProxy       *networkManager;
+  DKProxy<NetworkManager>       *networkManager;
 }
 
 - (void)deactivateConnection;


### PR DESCRIPTION
I rebuilt everything on Debian 12 with Clang 14.  The compiler complained with an error without this style declaration.